### PR TITLE
Validation for user pin from the backend.

### DIFF
--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/annotation/pin/UserPinConstraintValidator.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/annotation/pin/UserPinConstraintValidator.java
@@ -1,0 +1,20 @@
+package com.egovernment.egovbackend.domain.annotation.pin;
+
+import com.egovernment.egovbackend.validation.UserPinValidator;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UserPinConstraintValidator implements ConstraintValidator<ValidUserPin, String> {
+
+    private final UserPinValidator userPinValidator = new UserPinValidator();
+
+    @Override
+    public void initialize(ValidUserPin constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String userPin, ConstraintValidatorContext constraintValidatorContext) {
+        return this.userPinValidator.isPinValid(userPin);
+    }
+}

--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/annotation/pin/ValidUserPin.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/annotation/pin/ValidUserPin.java
@@ -1,0 +1,16 @@
+package com.egovernment.egovbackend.domain.annotation.pin;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UserPinConstraintValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidUserPin {
+    String message() default "Invalid User PIN. It must contain only digits and be exactly 10 digits long.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/dto/CensusDTO.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/dto/CensusDTO.java
@@ -1,6 +1,7 @@
 package com.egovernment.egovbackend.domain.dto;
 
 import com.egovernment.egovbackend.domain.annotation.census.UniqueCensusConstraint;
+import com.egovernment.egovbackend.domain.annotation.pin.ValidUserPin;
 import com.egovernment.egovbackend.domain.dto.censusCampaignDTO.UserAnswerDTO;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,6 +19,7 @@ import java.util.List;
 @UniqueCensusConstraint
 public class CensusDTO {
 
+    @ValidUserPin
     @NotBlank(message = "User PIN is required but it is not found.")
     private String userPin;
     @NotNull(message = "Campaign id is required but it is not found.")

--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/dto/campaignDto/UserVotedInfoDTO.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/dto/campaignDto/UserVotedInfoDTO.java
@@ -1,5 +1,6 @@
 package com.egovernment.egovbackend.domain.dto.campaignDto;
 
+import com.egovernment.egovbackend.domain.annotation.pin.ValidUserPin;
 import com.egovernment.egovbackend.domain.annotation.vote.UniqueVoteConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @UniqueVoteConstraint
 public class UserVotedInfoDTO {
 
+    @ValidUserPin
     @NotBlank(message = "User PIN is required but it is not found.")
     private String userPin;
     @NotNull(message = "Election id is required but it is not found.")

--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/entity/User.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/domain/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
     private String email;
     @Column
     private String password;
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.EAGER)
     private List<Role> roles = new ArrayList<>();
     @Column
     private String PIN;

--- a/e-gov-backend/src/main/java/com/egovernment/egovbackend/validation/UserPinValidator.java
+++ b/e-gov-backend/src/main/java/com/egovernment/egovbackend/validation/UserPinValidator.java
@@ -1,0 +1,14 @@
+package com.egovernment.egovbackend.validation;
+
+public class UserPinValidator {
+
+    public boolean isPinValid(String userPin) {
+        if (userPin == null) {
+            return false;
+        }
+
+        String regex = "^[0-9]{10}$";
+        return userPin.matches(regex);
+    }
+
+}


### PR DESCRIPTION
   1. Validation for the user PIN has been implemented as an annotation, which is applied to the CensusDTO and UserVotedInfoDTO classes for userPin fields. Testing with Postman confirms that the validation correctly rejects any user PIN shorter or longer than 10 digits, as well as any PIN containing characters other than digits.

   2.  The fetch type for roles in the User entity is temporarily set to EAGER until we find the problem with LAZY 
